### PR TITLE
Fix search permissions bug

### DIFF
--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -74,6 +74,11 @@ func (s *Searcher) SearchByContent(root, content string) ([]string, error) {
 		}
 		processedFilesMap[path] = true
 
+		// Проверяем права на чтение файла
+		if info.Mode().Perm()&0400 == 0 {
+			return nil // нет прав на чтение
+		}
+
 		// Открываем файл для чтения
 		file, err := os.Open(path)
 		if err != nil {


### PR DESCRIPTION
## Summary
- search: skip unreadable files in SearchByContent

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68414c5db0608332a7d67b9e1f0aa60c